### PR TITLE
Correct fretboard visualizer offset

### DIFF
--- a/client/src/components/fretboard.tsx
+++ b/client/src/components/fretboard.tsx
@@ -55,6 +55,8 @@ export default function Fretboard({
   };
 
   const renderNote = (note: FretboardNote, stringIndex: number, fretIndex: number) => {
+    // Skip rendering open-string note markers; the left labels already show tuning
+    if (fretIndex === 0) return null;
     // Show all notes by default, but allow filtering by options
     if (!showOptions.rootNotes && !showOptions.scaleNotes) {
       // Show all notes - continue to render
@@ -71,9 +73,9 @@ export default function Fretboard({
       // Fallback: show all notes if no specific case matches
     }
 
-    const x = fretIndex === 0
+    const x = fretIndex === 1
       ? nutX + fretWidth / 2
-      : startX + (fretIndex - 1) * fretWidth + fretWidth / 2;
+      : startX + (fretIndex - 2) * fretWidth + fretWidth / 2;
     const y = startY + (guitarType - 1 - stringIndex) * stringSpacing;
     
     const displayText = displayMode === "notes" ? note.note : note.interval;
@@ -229,7 +231,7 @@ export default function Fretboard({
             {showOptions.fretNumbers && Array.from({ length: fretRange }, (_, i) => {
               const x = i === 0
                 ? nutX + fretWidth / 2
-                : startX + i * fretWidth;
+                : startX + (i - 1) * fretWidth + fretWidth / 2;
               return (
                 <text
                   key={i}


### PR DESCRIPTION
Corrected the fretboard visualizer's note and fret number positioning to fix an off-by-one error where the first fret duplicated open string notes.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e53f1ac-d25b-4356-b095-548b0265b590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e53f1ac-d25b-4356-b095-548b0265b590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

